### PR TITLE
Rseqc odo

### DIFF
--- a/lcdblib/odo_backends/rseqc.py
+++ b/lcdblib/odo_backends/rseqc.py
@@ -1,0 +1,53 @@
+"""Backends for shapeshifting RseQC output to pandas dataframes."""
+import re
+from odo import resource
+import pandas as pd
+
+def ParsingError(Exception):
+    pass
+
+@resource.register('.*infer_experiment\.txt', priority=20)
+def resource(uri, **kwargs):
+    """odo resource to parse infer_experiment results."""
+    header = [
+        'Fraction of reads failed to assign',
+        'Fraction of reads on same strand as gene',
+        'Fraction of reads on opposite strand as gene',
+        'Read type',
+        ]
+
+    with open(uri, 'r') as fh:
+        data = fh.read().strip()
+        try:
+            # SingleEnd
+            se_regex = (
+                'This is SingleEnd Data\n'
+                'Fraction of reads failed to determine: (\d\.\d+)\n'
+                'Fraction of reads explained by \"\+\+\,\-\-\"\: (\d\.\d+)\n'
+                'Fraction of reads explained by \"\+\-\,\-\+\"\: (\d\.\d+)'
+                )
+
+            m = re.match(se_regex, data, flags=re.DOTALL).groups()
+            values = [float(x) for x in m]
+            values.append('SingleEnd')
+            return pd.Series(data=values, index=header)
+        except:
+            pass
+
+        try:
+            # PairEnd
+            pe_regex = (
+                'This is PairEnd Data\n'
+                'Fraction of reads failed to determine: (\d\.\d+)\n'
+                'Fraction of reads explained by \"1\+\+\,1\-\-,2\+\-\,2\-\+\"\: (\d\.\d+)\n'
+                'Fraction of reads explained by \"1\+\-\,1\-\+,2\+\+,2\-\-\"\: (\d\.\d+)'
+                )
+
+            m = re.match(pe_regex, data, flags=re.DOTALL).groups()
+            values = [float(x) for x in m]
+            values.append('PairEnd')
+            return pd.Series(data=values, index=header)
+        except:
+            pass
+
+        raise ParsingError('File did not conform to SE or PE read pattern.')

--- a/lcdblib/odo_backends/rseqc.py
+++ b/lcdblib/odo_backends/rseqc.py
@@ -1,6 +1,6 @@
 """Backends for shapeshifting RseQC output to pandas dataframes."""
 import re
-from odo import resource
+from odo import resource, append
 import pandas as pd
 
 
@@ -18,10 +18,10 @@ def resource_infer_experiment(uri, **kwargs):
 
     """
     header = [
-        'Fraction of reads failed to assign',
-        'Fraction of reads on same strand as gene',
-        'Fraction of reads on opposite strand as gene',
-        'Read type',
+        'Fraction_reads_failed_assignment',
+        'Fraction_reads_on_gene_strand',
+        'Fraction_reads_opposite_gene_strand',
+        'Read_type',
         ]
 
     with open(uri, 'r') as fh:

--- a/lcdblib/odo_backends/rseqc.py
+++ b/lcdblib/odo_backends/rseqc.py
@@ -1,6 +1,6 @@
 """Backends for shapeshifting RseQC output to pandas dataframes."""
 import re
-from odo import resource, append
+from odo import resource
 import pandas as pd
 
 

--- a/lcdblib/odo_backends/rseqc.py
+++ b/lcdblib/odo_backends/rseqc.py
@@ -3,12 +3,20 @@ import re
 from odo import resource
 import pandas as pd
 
-def ParsingError(Exception):
+
+class ParsingError(Exception):
     pass
 
+
 @resource.register('.*infer_experiment\.txt', priority=20)
-def resource(uri, **kwargs):
-    """odo resource to parse infer_experiment results."""
+def resource_infer_experiment(uri, **kwargs):
+    """odo resource to parse infer_experiment results.
+
+    Note
+    ----
+    The infer experiment file must be named `*infer_experiment.txt`.
+
+    """
     header = [
         'Fraction of reads failed to assign',
         'Fraction of reads on same strand as gene',
@@ -51,3 +59,57 @@ def resource(uri, **kwargs):
             pass
 
         raise ParsingError('File did not conform to SE or PE read pattern.')
+
+@resource.register('.*geneBody_coverage\.txt', priority=20)
+def resource_geneBody_coverage(uri, **kwargs):
+    """odo resource to parse geneBody_coverage results.
+
+    Note
+    ----
+    The gene body coverage file must be named `*geneBody_coverage.txt`.
+
+    """
+    df = pd.read_csv(uri, sep='\t', index_col=0)
+    df.index = [x.replace('.prealn', '') for x in df.index]
+    df.index.name = 'sample_id'
+    return df
+
+@resource.register('.*tin\.txt', priority=20)
+def resource_tin(uri, **kwargs):
+    """odo resource to parse tin results.
+
+    Note
+    ----
+    The gene body coverage file must be named `*tin.txt`.
+    """
+    df = pd.read_csv(uri, sep='\t', index_col=0)
+    df.index = [x.replace('.prealn.bam', '') for x in df.index]
+    df.index.name = 'sample_id'
+    return df
+
+@resource.register('.*bam_stat\.txt', priority=20)
+def resource_tin(uri, **kwargs):
+    """odo resource to parse bam_stat results.
+
+    Note
+    ----
+    The gene body coverage file must be named `*bam_stat.txt`.
+    """
+
+    header = ['Total_records', 'QC_failed', 'Optical_PCR_duplicate',
+              'Non_primary_hits', 'Unmapped_reads', 'non-unique',
+              'unique', 'Read_1', 'Read_2', 'Reads_map_plus', 'Reads_map_minus', 'NonSplice_reads',
+              'Splice_reads', 'Reads_mapped_in_proper_pairs',
+              'ProperPaired_reads_map_to_different_chrom']
+
+    with open(uri, 'r') as fh:
+        values = []
+        for row in fh:
+            row = row.strip()
+            try:
+                value = re.match(r'.*[\s\:](\d+)', row).groups()[0]
+                values.append(int(value))
+            except:
+                pass
+
+        return pd.Series(data=values, index=header)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pyyaml
 pybedtools
 pysam
 biopython
+odo

--- a/tests/test_odo_backends.py
+++ b/tests/test_odo_backends.py
@@ -2,9 +2,10 @@
 
 import os
 import pytest
+from math import ceil
 from odo import odo, resource
 import pandas as pd
-from lcdblib.odo_backends import rseqc
+from lcdblib.odo_backends.rseqc import *
 
 
 @pytest.fixture
@@ -44,3 +45,76 @@ def test_infer_experiment_pe(infer_experiment_pe):
     assert dat[1] == 0.0126
     assert dat[2] == 0.7345
     assert dat[3] == 'PairEnd'
+
+@pytest.fixture
+def geneBody_coverage(tmpdir):
+    data = (
+        'Percentile	1	2	3	4	5	6	7	8	9	10\n'
+        'SRR9999999.prealn	46.0	70.0	115.0	154.0	224.0	246.0	275.0	343.0	418.0	457.0')
+    fn = os.path.join(str(tmpdir), 'test_geneBody_coverage.txt')
+    with open(fn, 'w') as fh:
+        fh.write(data)
+    return fn
+
+def test_geneBody_coverage(geneBody_coverage):
+    dat = resource(geneBody_coverage)
+    assert dat.iloc[0, 0] == 46.0
+    assert dat.columns[0] == '1'
+    assert dat.index[0] == 'SRR9999999'
+    assert dat.index.name == 'sample_id'
+
+
+@pytest.fixture
+def tin(tmpdir):
+    data = (
+        'Bam_file	TIN(mean)	TIN(median)	TIN(stdev)\n'
+        'SRR9999999.prealn.bam	25.6425321019	22.2814373475	17.9599093927')
+    fn = os.path.join(str(tmpdir), 'test_tin.txt')
+    with open(fn, 'w') as fh:
+        fh.write(data)
+    return fn
+
+def test_tin(tin):
+    dat = resource(tin)
+    assert ceil(dat.iloc[0, 0]) == 26
+    assert dat.columns[0] == 'TIN(mean)'
+    assert dat.index[0] == 'SRR9999999'
+    assert dat.index.name == 'sample_id'
+
+
+@pytest.fixture
+def bam_stat(tmpdir):
+    data = (
+        'Load BAM file ...  Done\n'
+        '\n'
+        '#==================================================\n'
+        '#All numbers are READ count\n'
+        '#==================================================\n'
+        '\n'
+        'Total records:                          3759051\n'
+        '\n'
+        'QC failed:                              0\n'
+        'Optical/PCR duplicate:                  0\n'
+        'Non primary hits                        0\n'
+        'Unmapped reads:                         0\n'
+        'mapq < mapq_cut (non-unique):           0\n'
+        '\n'
+        'mapq >= mapq_cut (unique):              3759051\n'
+        'Read-1:                                 1892634\n'
+        'Read-2:                                 1866417\n'
+        '''Reads map to '+':                       1880063\n'''
+        '''Reads map to '-':                       1878988\n'''
+        'Non-splice reads:                       3484515\n'
+        'Splice reads:                           274536\n'
+        'Reads mapped in proper pairs:           3474678\n'
+        'Proper-paired reads map to different chrom:0')
+
+    fn = os.path.join(str(tmpdir), 'test_bam_stat.txt')
+    with open(fn, 'w') as fh:
+        fh.write(data)
+    return fn
+
+def test_bam_stat(bam_stat):
+    dat = resource(bam_stat)
+    assert dat[0] == 3759051
+    assert dat[-1] == 0

--- a/tests/test_odo_backends.py
+++ b/tests/test_odo_backends.py
@@ -1,0 +1,46 @@
+"""Tests for odo backends."""
+
+import os
+import pytest
+from odo import odo, resource
+import pandas as pd
+from lcdblib.odo_backends import rseqc
+
+
+@pytest.fixture
+def infer_experiment_se(tmpdir):
+    data = (
+    'This is SingleEnd Data\n'
+    'Fraction of reads failed to determine: 0.0964\n'
+    'Fraction of reads explained by "++,--": 0.1195\n'
+    'Fraction of reads explained by "+-,-+": 0.7841')
+    fn = os.path.join(str(tmpdir), 'test_infer_experiment.txt')
+    with open(fn, 'w') as fh:
+        fh.write(data)
+    return fn
+
+@pytest.fixture
+def infer_experiment_pe(tmpdir):
+    data = (
+        'This is PairEnd Data\n'
+        'Fraction of reads failed to determine: 0.2530\n'
+        'Fraction of reads explained by "1++,1--,2+-,2-+": 0.0126\n'
+        'Fraction of reads explained by "1+-,1-+,2++,2--": 0.7345')
+    fn = os.path.join(str(tmpdir), 'test_infer_experiment.txt')
+    with open(fn, 'w') as fh:
+        fh.write(data)
+    return fn
+
+def test_infer_experiment_se(infer_experiment_se):
+    dat = resource(infer_experiment_se)
+    assert dat[0] == 0.0964
+    assert dat[1] == 0.1195
+    assert dat[2] == 0.7841
+    assert dat[3] == 'SingleEnd'
+
+def test_infer_experiment_pe(infer_experiment_pe):
+    dat = resource(infer_experiment_pe)
+    assert dat[0] == 0.2530
+    assert dat[1] == 0.0126
+    assert dat[2] == 0.7345
+    assert dat[3] == 'PairEnd'


### PR DESCRIPTION
This PR includes odo shapeshifting for the following rseqc tools:

* infer experiment
* tin
* gene body coverage
* bam stat

Odo is extended by registering `resource`, `convert`, `append`, `discover` functions. Luckily since we are mostly wanting to work with pandas `DataFrame` and `Series` we really only need to write `resources` that produce either a `pd.DataFrame` or `pd.Series` and then we can take advantage of all of the build in converters if we need to.

A file naming pattern is given to the `@resource.register` followed by a parsing function. I found it necessary to give an increased priority to the new resources because there are already registered functions for dealing with `*.txt` files that I wanted to override for specific file name patterns.

To use odo you need to `resource, convert, ...` from odo and import the correct backend module `from lcdblib.odo_backends import reseqc`. 

Then the  `resource` function is used to parse a given file or the `convert` function is used to parse the file and convert to some other data type. Here is a quick example:

```python
from odo import resource, convert
from lcdblib.odo_backend import reseqc
import pandas as pd

fn = 'test_bam_stat.txt'

# To just make a `pd.Series` you would just do:
sf = resource(fn)

# If you want a data frame instead you could do
df = odo(fn, pd.DataFrame)
```

For some of the rseqc output I create a `pd.Series` (infer_experiment, bam_stat) and other I create a `pd.DataFrame` (tin, geneBody_coverage). I picked these data types based on the output, but maybe we just want to make everything a `pd.DataFrame`. 

Any thoughts?