### PR TITLE
Adds logic to return prefix if given a single index

### DIFF
--- a/lcdblib/snakemake/aligners.py
+++ b/lcdblib/snakemake/aligners.py
@@ -13,10 +13,13 @@ def prefix_from_hisat2_index(index_files):
     """
     Given a list of index files for hisat2, return the corresponding prefix.
     """
-    prefixes = list(set(map(lambda x: '.'.join(x.split('.')[:-2]), index_files)))
-    if len(prefixes) != 1:
-        raise ValueError("More than one prefix detected from '{0}'".format(prefixes))
-    return prefixes[0]
+    if isinstance(index_files, str):
+        return '.'.join(index_files.split('.')[:-2])
+    else:
+        prefixes = list(set(map(lambda x: '.'.join(x.split('.')[:-2]), index_files)))
+        if len(prefixes) != 1:
+            raise ValueError("More than one prefix detected from '{0}'".format(prefixes))
+        return prefixes[0]
 
 
 def bowtie2_index_from_prefix(prefix):
@@ -38,7 +41,10 @@ def prefix_from_bowtie2_index(index_files):
     """
     Given a list of index files for bowtie2, return the corresponding prefix.
     """
-    prefixes = list(set(map(lambda x: '.'.join(x.replace('.rev', '').split('.')[:-2]), index_files)))
-    if len(prefixes) != 1:
-        raise ValueError("More than one prefix detected from '{0}'".format(prefixes))
-    return prefixes[0]
+    if isinstance(index_files, str):
+        return '.'.join(index_files.replace('.rev', '').split('.')[:-2])
+    else:
+        prefixes = list(set(map(lambda x: '.'.join(x.replace('.rev', '').split('.')[:-2]), index_files)))
+        if len(prefixes) != 1:
+            raise ValueError("More than one prefix detected from '{0}'".format(prefixes))
+        return prefixes[0]

--- a/tests/test_aligners.py
+++ b/tests/test_aligners.py
@@ -14,6 +14,7 @@ def test_hisat2_prefixes():
 
     assert aligners.hisat2_index_from_prefix('a/b/c') == files
     assert aligners.prefix_from_hisat2_index(files) == 'a/b/c'
+    assert aligners.prefix_from_hisat2_index(files[0]) == 'a/b/c'
 
     with pytest.raises(ValueError):
         aligners.prefix_from_hisat2_index(['a/b.1.ht2', 'z/b.2.ht2'])
@@ -31,6 +32,7 @@ def test_bowtie2_prefixes():
 
     assert aligners.bowtie2_index_from_prefix('a/b/c') == files
     assert aligners.prefix_from_bowtie2_index(files) == 'a/b/c'
+    assert aligners.prefix_from_bowtie2_index(files[0]) == 'a/b/c'
 
     with pytest.raises(ValueError):
         aligners.prefix_from_bowtie2_index(['a/b.1.bt2', 'z/b.2.bt2'])


### PR DESCRIPTION
I was finding instances when I just wanted to use a single index file name, but would have to wrap it as a list so not to break the get prefix functions. Added logic to test if a string was given, and then parse correctly and return the prefix.