### PR TITLE
flatten should return string when given string

### DIFF
--- a/lcdblib/plotting/results_table.py
+++ b/lcdblib/plotting/results_table.py
@@ -711,7 +711,7 @@ class DifferentialExpressionResults(ResultsTable):
         super(DifferentialExpressionResults, self).__init__(
             data=data, db=db, import_kwargs=import_kwargs, **kwargs)
 
-    def changed(self, alpha=0.05, lfc=0, idx=True):
+    def changed(self, alpha=0.1, lfc=0, idx=True):
         """
         Changed features.
 
@@ -737,7 +737,7 @@ class DifferentialExpressionResults(ResultsTable):
             return ind
         return self[ind]
 
-    def unchanged(self, alpha=0.05, lfc=0, idx=True):
+    def unchanged(self, alpha=0.1, lfc=0, idx=True):
         """
         Unchanged features.
 
@@ -759,7 +759,7 @@ class DifferentialExpressionResults(ResultsTable):
             return ind
         return self[ind]
 
-    def upregulated(self, alpha=0.05, lfc=0, idx=True):
+    def upregulated(self, alpha=0.1, lfc=0, idx=True):
         """
         Upregulated features.
 
@@ -784,7 +784,7 @@ class DifferentialExpressionResults(ResultsTable):
             return ind
         return self[ind]
 
-    def downregulated(self, alpha=0.05, lfc=0, idx=True):
+    def downregulated(self, alpha=0.1, lfc=0, idx=True):
         """
         Downregulated features.
 

--- a/lcdblib/utils/utils.py
+++ b/lcdblib/utils/utils.py
@@ -55,6 +55,7 @@ def test_flatten():
     })) == ['a', 'b', 'c', 'd', 'e', 'f', 'g']
 
     assert flatten('a') == 'a'
+    assert flatten(['a']) == 'a'
 
 
 def updatecopy(orig, update_with, keys=None, override=False):

--- a/lcdblib/utils/utils.py
+++ b/lcdblib/utils/utils.py
@@ -35,7 +35,10 @@ def flatten(iter):
                 yield from flatten(item)
             else:
                 yield item
-    return list(gen())
+    results = list(gen())
+    if len(results) == 1:
+        return results[0]
+    return results
 
 
 def test_flatten():
@@ -50,6 +53,8 @@ def test_flatten():
             'z': 'd'
         },
     })) == ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+
+    assert flatten('a') == 'a'
 
 
 def updatecopy(orig, update_with, keys=None, override=False):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -90,7 +90,7 @@ def test_up_down(deseq_results):
     assert list(r.upregulated(idx=False).index) == [ 'g1', 'g3', 'g5', 'g18']
     assert list(r.upregulated(alpha=0.01, idx=False).index) == [ 'g1', 'g3', 'g5']
     assert list(r.upregulated(alpha=0.01, lfc=3.5, idx=False).index) == ['g3']
-    assert list(r.downregulated(idx=False).index) == [ 'g2', 'g4', 'g10', 'g11', 'g14']
+    assert list(r.downregulated(idx=False).index) == [ 'g2', 'g4', 'g10', 'g11', 'g14', 'g24']
     assert list(r.downregulated(alpha=0.01, idx=False).index) == ['g2', 'g4', 'g11', 'g14']
     assert list(r.downregulated(alpha=0.01, lfc=-3.5, idx=False).index) == ['g2']
 


### PR DESCRIPTION
Before:

`flatten('a') == ['a']`.

Not so flat, is it?

Now:

`flatten('a') == 'a'`
`flatten(['a']) == 'a'`
`flatten(['a', ['b', 'c']]) == ['a', 'b', 'c']`.

This also includes a change to the default alpha in `results_table`.
