### PR TITLE
remove R channel

### DIFF
--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -8,10 +8,10 @@ export PATH=~/anaconda/bin:$PATH
 # Add channels in the specified order.
 conda config --add channels conda-forge
 conda config --add channels defaults
-conda config --add channels r
+#conda config --add channels r
 conda config --add channels bioconda
 
-conda install -y python=3.5 sphinx
+conda install -y sphinx
 conda install -y --file requirements.txt
 
 # we also want conda-build to build a conda package

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -11,9 +11,9 @@ conda config --add channels defaults
 #conda config --add channels r
 conda config --add channels bioconda
 
-conda install -y sphinx
-conda install -y "conda<4.3"
-conda install -y --file requirements.txt
+conda install -y sphinx "python=3.5" "conda<4.3"
+
+conda install -y --file requirements.txt -vv
 
 # we also want conda-build to build a conda package
 conda install -y conda-build

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -12,6 +12,7 @@ conda config --add channels defaults
 conda config --add channels bioconda
 
 conda install -y sphinx
+conda install -y "conda<4.3"
 conda install -y --file requirements.txt
 
 # we also want conda-build to build a conda package

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -11,7 +11,7 @@ conda config --add channels defaults
 #conda config --add channels r
 conda config --add channels bioconda
 
-conda install -y sphinx "python=3.5" "conda<4.3"
+conda install -y sphinx  "conda<4.3"
 
 conda install -y --file requirements.txt -vv
 

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -2,7 +2,6 @@ name: lcdblib
 channels:
   - bioconda
   - defaults
-  - r
   - conda-forge
 dependencies:
   - biopython>=1.68

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-biopython >=1.68
-gffutils >=0.8.7.1
-ipython >=5.1.0
-jsonschema >=2.5.1
-matplotlib >=1.5.3
-numpy >=1.11.3
-pandas >=0.19.2
-pybedtools >=0.7.9
-pysam >=0.10.0
-pytest >=3.0.5
-pyyaml >=3.12
-seaborn >=0.7.1
-scipy >=0.18.1
-snakemake >=3.11.2
+biopython
+gffutils
+ipython
+jsonschema
+matplotlib
+numpy
+pandas
+pybedtools
+pysam
+pytest
+pyyaml
+seaborn
+scipy
+snakemake


### PR DESCRIPTION
bioconda recently migrated all R packages over to conda-forge with the goal of dropping continuumIO's `r` channel since it is infrequently updated and is not easily maintained by the community.

However, now that there are many packages duplicated across both `conda-forge` and `r` channels, the conda solver hangs indefinitely when both channels are activated. The solution is to not only remove the `r` channel from `.condarc` with `conda config --remove channels r` but **also downgrade conda**. This is because as of `conda=4.3`, the `r` channel was added to defaults, and there's not a good way of removing it.

So locally, you should do

```bash
conda config --remove channels r
conda install -n root "conda<4.3"
```

This is effectively what this PR is doing.

This took a lot of annoying troubleshooting, and I'm still working on lcdb-wf after days of mucking around with this. But I'm pretty sure this was the underlying problem causing our tests to fail. There was another issue, where the `argh` package was not available on py36, and since `gffutils` depends on `argh`, `gffutils` couldn't be installed with everything else. This was a separate problem, which has since been fixed by bumping the version number in the `conda-forge` recipe (as well as learning the ropes for using the conda-forge build system).

Awful lot of work just to keep existing tests from failing due to conda solver timeouts.