### PR TITLE
Fix recipe

### DIFF
--- a/ci/conda-build-and-upload.sh
+++ b/ci/conda-build-and-upload.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 export LCDBLIB_VERSION=$(python -c 'from lcdblib import __conda_version__; print(__conda_version__)')
 export LCDBLIB_BUILD=$(python -c 'from lcdblib import __conda_build__; print(__conda_build__)')

--- a/ci/conda-build-and-upload.sh
+++ b/ci/conda-build-and-upload.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 export LCDBLIB_VERSION=$(python -c 'from lcdblib import __conda_version__; print(__conda_version__)')
 export LCDBLIB_BUILD=$(python -c 'from lcdblib import __conda_build__; print(__conda_build__)')
 
-conda build conda-recipe
-
-# Always build with conda to test any build issues, but only upload if we're on
-# master branch and it's not a pull request.
 if [[ $TRAVIS_BRANCH = "master" && $TRAVIS_PULL_REQUEST = "false" ]]; then
   conda install anaconda-client -y
-  anaconda \
-    -t $ANACONDA_TOKEN \
-    upload \
-    -u lcdb \
-    $(conda build --output conda-recipe)
 fi
+
+# Build packages for all supported versions of Python. If we're on the master
+# branch and on Travis-CI, then also upload the built package.
+for PY in 35 36; do
+    CONDA_PY=$PY conda build conda-recipe
+    if [[ $TRAVIS_BRANCH = "master" && $TRAVIS_PULL_REQUEST = "false" ]]; then
+      anaconda \
+        -t $ANACONDA_TOKEN \
+        upload \
+        -u lcdb \
+        $(CONDA_PY=$PY conda build --output conda-recipe)
+    fi
+done

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-$PYTHON setup.py install
+
+$PYTHON setup.py clean install --single-version-externally-managed --record /tmp/$PKG_NAME.log
 
 # copy scripts over
 mv ./bin/* "$PREFIX/bin/"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -2,9 +2,7 @@ package:
   name: lcdblib
   version: {{ LCDBLIB_VERSION }}
 source:
-  git_url: https://github.com/lcdb/lcdblib.git
-  git_rev: master
-
+  path: ..
 build:
   number: {{ LCDBLIB_BUILD }}
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,6 +8,7 @@ build:
 
 requirements:
   build:
+    - python
     - biopython >=1.68
     - gffutils >=0.8.7.1
     - ipython >=5.1.0
@@ -26,6 +27,7 @@ requirements:
     - samtools >=1.4.1
 
   run:
+    - python
     - biopython >=1.68
     - gffutils >=0.8.7.1
     - ipython >=5.1.0


### PR DESCRIPTION
There were a couple problems with the recipe building, I'm actually kind of surprised it worked before.


- recipe building script uses `set -e` so it actually exits with 1 rather than 0. Previously the recipe build could fail, yet travis tests would still pass (!)
- fix recipe `build.sh` with stuff I learned from fixing pyfaidx and gffutils conda recipes
- fix recipe `source:` to point to `..`, so the PR testing actually tests the code in the PR, not what's on master branch.
- add `python` as dependency
- build for multiple versions of python
